### PR TITLE
drop set -e

### DIFF
--- a/etc/initramfs-tools/scripts/local-bottom/boundbox
+++ b/etc/initramfs-tools/scripts/local-bottom/boundbox
@@ -35,12 +35,11 @@ esac
 
 [ -s /run/boundbox.pid ] || exit 0
 
-set -e
-
 if [ -e /etc/boundbox/boundbox.conf ]; then
   . /etc/boundbox/boundbox.conf
 fi
 . /scripts/functions
+
 
 pid=$(cat /run/boundbox.pid)
 child_pids="$({ ps -o pid,ppid 2>/dev/null || ps -l ||

--- a/etc/initramfs-tools/scripts/local-top/boundbox
+++ b/etc/initramfs-tools/scripts/local-top/boundbox
@@ -29,8 +29,6 @@ case $1 in
 prereqs) exit 0 ;;
 esac
 
-set -e
-
 if [ -e /etc/boundbox/boundbox.conf ]; then
     . /etc/boundbox/boundbox.conf
 fi
@@ -214,6 +212,8 @@ for f in /etc/boundbox/key /etc/boundbox/login /etc/boundbox/known_hosts; do
         exit 0
     fi
 done
+
+echo "Starting Boundbox..."
 
 boundboxloop &
 echo $! >/run/boundbox.pid

--- a/etc/initramfs-tools/scripts/local-top/boundbox
+++ b/etc/initramfs-tools/scripts/local-top/boundbox
@@ -87,7 +87,7 @@ luks2_decrypt() {
     [ $? -eq 0 ] || continue
     [ -n "${__salt}" ] || continue
 
-    echo "calling boundbox upstream: ${__login}@${BOUNDBOX_UPSTREAM}"
+    echo "calling boundbox: ${__login}@${BOUNDBOX_UPSTREAM}"
     local __rsp
     __rsp=$(echo '{"salt":"'"${__salt}"'"}' | ssh "${BOUNDBOX_UPSTREAM}" \
       -l "${__login}" \


### PR DESCRIPTION
We can't use `set -e` due to network configuration may fail:
```
Begin: Waiting up to 180 secs for any network device to become available ... done.
Begin: Mounting root file system ... Begin: Running /scripts/local-top ... done.
IP-Config: end0 hardware address 02:00:b0:1a:3f:10 mtu 1500 DHCP RARP

Please unlock disk armbian-root:IP-Config: no response after 2 secs - giving up
IP-Config: end0 hardware address 02:00:b0:1a:3f:10 mtu 1500 DHCP RARP
IP-Config: end0 complete (dhcp from 10.13.0.1):
 address: 10.13.0.197      broadcast: 10.13.255.255    netmask: 255.255.0.0     
 gateway: 10.13.0.1        dns0     : 10.13.0.1        dns1   : 0.0.0.0         
 domain : lan                                                             
 rootserver: 10.13.0.1 rootpath: 
 filename  : 
```